### PR TITLE
Fix OCR version compatibility for rapidocr-onnxruntime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ flask>=3.0.0
 flask-sqlalchemy>=3.1.0
 python-dotenv>=1.0.0
 pillow>=10.0.0
-rapidocr-onnxruntime>=1.4.0
+# rapidocr-onnxruntime: 支持 1.3.x - 1.4.x，代码已兼容不同版本的输出格式
+rapidocr-onnxruntime>=1.3.0,<2.0.0
 yfinance>=0.2.0
 akshare>=1.10.0
 exchange-calendars>=4.5.0


### PR DESCRIPTION
- Add OcrResultParser class to handle different output formats between rapidocr-onnxruntime versions (1.3.x vs 1.4.x)
- Support both tuple and object return formats
- Support both list and dict item formats in results
- Add version detection and logging for debugging
- Update requirements.txt to specify version range (1.3.0-2.0.0)

This fixes issues where users cloning from GitHub may have different rapidocr-onnxruntime versions installed.

Slack thread: https://strangeblock.slack.com/archives/C0ADLCU38Q2/p1770454208952879

https://claude.ai/code/session_013JWj494WGQHURSDGJXcMif