### PR TITLE
feat: 添加 Redis 缓存配置

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,3 +28,25 @@ SECRET_KEY=
 #
 # 注意: private.db 不受影响，始终使用本地 SQLite
 # COCKROACH_URL=
+
+# ============ Redis 缓存配置 ============
+# 配置后将使用 Redis 作为缓存层，提升数据访问性能
+# 如果不配置，将使用数据库作为缓存
+
+# Redis 连接 URL（推荐方式）
+# 格式: redis://[:password@]host:port/db
+# 示例: redis://localhost:6379/0
+# 示例（带密码）: redis://:mypassword@localhost:6379/0
+# REDIS_URL=
+
+# 或者使用单独的配置项（REDIS_URL 优先级更高）
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=
+# REDIS_DB=0
+
+# Redis 连接超时（秒）
+# REDIS_TIMEOUT=5
+
+# Redis 键前缀（用于区分不同应用）
+# REDIS_KEY_PREFIX=gsstock:

--- a/config.py
+++ b/config.py
@@ -26,6 +26,35 @@ def is_cockroach_configured():
     return bool(os.environ.get('COCKROACH_URL'))
 
 
+def get_redis_url():
+    """获取 Redis 连接 URL
+
+    优先级：
+    1. REDIS_URL 环境变量
+    2. 通过 REDIS_HOST/PORT/PASSWORD/DB 组装
+    3. 返回 None 表示不使用 Redis
+    """
+    redis_url = os.environ.get('REDIS_URL')
+    if redis_url:
+        return redis_url
+
+    redis_host = os.environ.get('REDIS_HOST')
+    if redis_host:
+        redis_port = os.environ.get('REDIS_PORT', '6379')
+        redis_password = os.environ.get('REDIS_PASSWORD', '')
+        redis_db = os.environ.get('REDIS_DB', '0')
+        if redis_password:
+            return f'redis://:{redis_password}@{redis_host}:{redis_port}/{redis_db}'
+        return f'redis://{redis_host}:{redis_port}/{redis_db}'
+
+    return None
+
+
+def is_redis_configured():
+    """检查是否配置了 Redis"""
+    return bool(get_redis_url())
+
+
 def get_local_stock_db_path():
     """获取本地 stock.db 路径"""
     return os.path.join(basedir, 'data', 'stock.db')
@@ -55,3 +84,9 @@ class Config:
     OCR_TIMEOUT = 60             # 识别超时（秒）
     OCR_USE_GPU = True           # 是否启用 GPU
     OCR_GPU_BACKEND = 'auto'     # 'auto', 'cuda', 'directml', 'cpu'
+
+    # Redis 缓存配置
+    REDIS_URL = get_redis_url()
+    REDIS_CONFIGURED = is_redis_configured()
+    REDIS_TIMEOUT = int(os.environ.get('REDIS_TIMEOUT', '5'))
+    REDIS_KEY_PREFIX = os.environ.get('REDIS_KEY_PREFIX', 'gsstock:')


### PR DESCRIPTION
在 .env.sample 和 config.py 中添加 Redis 配置支持：
- 支持 REDIS_URL 或单独配置项 (HOST/PORT/PASSWORD/DB)
- 添加连接超时和键前缀配置
- 遵循与 CockroachDB 相同的配置模式

https://claude.ai/code/session_01PZKxMDhYf57mH8dSrX4Q4S