### PR TITLE
refactor(ui): 合并股票管理按钮到"我的"菜单，默认打开每日简报

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,4 +1,4 @@
-from flask import render_template, request, jsonify
+from flask import render_template, request, jsonify, redirect, url_for
 from app.routes import main_bp
 from app.services.position import PositionService
 from app.services.category import CategoryService
@@ -11,6 +11,12 @@ from app.models.daily_snapshot import DailySnapshot
 
 @main_bp.route('/')
 def index():
+    """Default page redirects to daily briefing"""
+    return redirect(url_for('briefing.index'))
+
+
+@main_bp.route('/dashboard')
+def dashboard():
     latest_date = PositionService.get_latest_date()
     positions = []
     advices = {}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,7 +13,7 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container">
-            <a class="navbar-brand" href="{{ url_for('main.index') }}">股票管理</a>
+            <a class="navbar-brand" href="{{ url_for('main.dashboard') }}">股票管理</a>
             {% if readonly_mode %}
             <span class="badge bg-warning text-dark ms-2" title="只读模式：仅使用缓存数据，不从服务器获取实时数据">
                 <i class="bi bi-lock"></i> 只读模式
@@ -35,9 +35,10 @@
                         <li><a class="dropdown-item" href="{{ url_for('profit.overall') }}"><i class="bi bi-pie-chart"></i> 整体收益</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="{{ url_for('rebalance.index') }}"><i class="bi bi-sliders"></i> 仓位配平</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><a class="dropdown-item" href="{{ url_for('stock.manage') }}"><i class="bi bi-tags"></i> 股票管理</a></li>
                     </ul>
                 </li>
-                <a class="nav-link" href="{{ url_for('stock.manage') }}">股票代码</a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
- 移除主导航栏的"股票代码"按钮
- 将"股票管理"选项添加到"我的"下拉菜单
- 首页(/)默认重定向到每日简报页面
- 原首页内容移至 /dashboard 路由

Slack thread: https://gsstockco.slack.com/archives/C0ADZUWME49/p1770631781926399

https://claude.ai/code/session_01CoiTg8KDYZ7m59hbT86J2o