### PR TITLE
添加交易策略页面

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -148,7 +148,7 @@ def create_app(config_class=None):
         stock_db_path, _ = get_db_paths(app)
         cleanup_legacy_tables(stock_db_path)
 
-    from app.routes import main_bp, position_bp, advice_bp, category_bp, trade_bp, wyckoff_bp, stock_bp, daily_record_bp, profit_bp, rebalance_bp, heavy_metals_bp, preload_bp, alert_bp, briefing_bp
+    from app.routes import main_bp, position_bp, advice_bp, category_bp, trade_bp, wyckoff_bp, stock_bp, daily_record_bp, profit_bp, rebalance_bp, heavy_metals_bp, preload_bp, alert_bp, briefing_bp, strategy_bp
     app.register_blueprint(main_bp)
     app.register_blueprint(position_bp)
     app.register_blueprint(advice_bp)
@@ -163,9 +163,10 @@ def create_app(config_class=None):
     app.register_blueprint(preload_bp)
     app.register_blueprint(alert_bp)
     app.register_blueprint(briefing_bp)
+    app.register_blueprint(strategy_bp)
 
     with app.app_context():
-        from app.models import Position, Advice, Category, StockCategory, Trade, Settlement, WyckoffReference, WyckoffAnalysis, Stock, StockAlias, StockWeight, PreloadStatus, DailySnapshot, PositionPlan, SignalCache, UnifiedStockCache
+        from app.models import Position, Advice, Category, StockCategory, Trade, Settlement, WyckoffReference, WyckoffAnalysis, Stock, StockAlias, StockWeight, PreloadStatus, DailySnapshot, PositionPlan, SignalCache, UnifiedStockCache, TradingStrategy, StrategyExecution
 
         # 检查是否需要执行 CockroachDB 迁移
         from app.services.cockroach_migration import check_cockroach_migration_needed, migrate_local_to_cockroach

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -17,5 +17,6 @@ from app.models.rebalance_config import RebalanceConfig
 from app.models.signal_cache import SignalCache
 from app.models.unified_cache import UnifiedStockCache
 from app.models.bank_transfer import BankTransfer
+from app.models.trading_strategy import TradingStrategy, StrategyExecution
 
-__all__ = ['Position', 'Advice', 'Config', 'Category', 'StockCategory', 'Trade', 'Settlement', 'WyckoffReference', 'WyckoffAnalysis', 'Stock', 'StockAlias', 'StockWeight', 'MetalTrendCache', 'IndexTrendCache', 'PreloadStatus', 'DailySnapshot', 'PositionPlan', 'RebalanceConfig', 'SignalCache', 'UnifiedStockCache', 'BankTransfer']
+__all__ = ['Position', 'Advice', 'Config', 'Category', 'StockCategory', 'Trade', 'Settlement', 'WyckoffReference', 'WyckoffAnalysis', 'Stock', 'StockAlias', 'StockWeight', 'MetalTrendCache', 'IndexTrendCache', 'PreloadStatus', 'DailySnapshot', 'PositionPlan', 'RebalanceConfig', 'SignalCache', 'UnifiedStockCache', 'BankTransfer', 'TradingStrategy', 'StrategyExecution']

--- a/app/models/trading_strategy.py
+++ b/app/models/trading_strategy.py
@@ -1,0 +1,102 @@
+"""交易策略模型"""
+from datetime import datetime
+from app import db
+
+
+class TradingStrategy(db.Model):
+    """交易策略模型
+
+    用于存储和管理交易策略规则，例如：
+    - 当纳指提前透支晚上涨幅，可以先卖出，买入达链或者谷歌链
+    """
+    __bind_key__ = 'private'
+    __tablename__ = 'trading_strategies'
+    __table_args__ = (
+        db.Index('idx_strategy_active', 'is_active'),
+        db.Index('idx_strategy_category', 'category'),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)  # 策略名称
+    category = db.Column(db.String(50), nullable=False, default='general')  # 策略分类
+
+    # 触发条件
+    trigger_condition = db.Column(db.Text, nullable=False)  # 触发条件描述
+    trigger_market = db.Column(db.String(20), nullable=True)  # 触发市场: A股/美股/港股
+    trigger_index = db.Column(db.String(50), nullable=True)  # 触发指数代码
+
+    # 操作建议
+    action_type = db.Column(db.String(20), nullable=False)  # 操作类型: buy/sell/switch
+    sell_target = db.Column(db.String(200), nullable=True)  # 卖出标的（多个用逗号分隔）
+    buy_target = db.Column(db.String(200), nullable=True)  # 买入标的（多个用逗号分隔）
+
+    # 详细描述
+    description = db.Column(db.Text, nullable=True)  # 策略详细说明
+    notes = db.Column(db.Text, nullable=True)  # 备注
+
+    # 状态
+    is_active = db.Column(db.Boolean, default=True)  # 是否启用
+    priority = db.Column(db.Integer, default=0)  # 优先级，数值越大优先级越高
+
+    # 时间戳
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'category': self.category,
+            'trigger_condition': self.trigger_condition,
+            'trigger_market': self.trigger_market,
+            'trigger_index': self.trigger_index,
+            'action_type': self.action_type,
+            'sell_target': self.sell_target,
+            'buy_target': self.buy_target,
+            'description': self.description,
+            'notes': self.notes,
+            'is_active': self.is_active,
+            'priority': self.priority,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class StrategyExecution(db.Model):
+    """策略执行记录"""
+    __bind_key__ = 'private'
+    __tablename__ = 'strategy_executions'
+    __table_args__ = (
+        db.Index('idx_execution_date', 'execution_date'),
+        db.Index('idx_execution_strategy', 'strategy_id'),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    strategy_id = db.Column(db.Integer, db.ForeignKey('trading_strategies.id'), nullable=False)
+    execution_date = db.Column(db.Date, nullable=False)
+
+    # 执行详情
+    triggered_by = db.Column(db.String(200), nullable=True)  # 触发原因
+    action_taken = db.Column(db.Text, nullable=True)  # 实际执行的操作
+    result = db.Column(db.String(20), nullable=True)  # 执行结果: success/partial/skipped
+    profit_loss = db.Column(db.Float, nullable=True)  # 盈亏金额
+    notes = db.Column(db.Text, nullable=True)  # 执行备注
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    # 关联
+    strategy = db.relationship('TradingStrategy', backref=db.backref('executions', lazy='dynamic'))
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'strategy_id': self.strategy_id,
+            'strategy_name': self.strategy.name if self.strategy else None,
+            'execution_date': self.execution_date.isoformat() if self.execution_date else None,
+            'triggered_by': self.triggered_by,
+            'action_taken': self.action_taken,
+            'result': self.result,
+            'profit_loss': self.profit_loss,
+            'notes': self.notes,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -14,5 +14,6 @@ heavy_metals_bp = Blueprint('heavy_metals', __name__, url_prefix='/heavy-metals'
 preload_bp = Blueprint('preload', __name__)
 alert_bp = Blueprint('alert', __name__, url_prefix='/alert')
 briefing_bp = Blueprint('briefing', __name__, url_prefix='/briefing')
+strategy_bp = Blueprint('strategy', __name__, url_prefix='/strategies')
 
-from app.routes import main, position, advice, category, trade, wyckoff, stock, daily_record, profit, rebalance, heavy_metals, preload, alert, briefing
+from app.routes import main, position, advice, category, trade, wyckoff, stock, daily_record, profit, rebalance, heavy_metals, preload, alert, briefing, strategy

--- a/app/routes/strategy.py
+++ b/app/routes/strategy.py
@@ -1,0 +1,152 @@
+"""交易策略路由"""
+from flask import request, jsonify, render_template
+from app.routes import strategy_bp
+from app.services.trading_strategy import TradingStrategyService
+
+
+@strategy_bp.route('/')
+def index():
+    """交易策略主页"""
+    strategies = TradingStrategyService.get_all_strategies(include_inactive=True)
+    statistics = TradingStrategyService.get_statistics()
+    return render_template(
+        'trading_strategy.html',
+        strategies=strategies,
+        statistics=statistics,
+        categories=TradingStrategyService.CATEGORIES,
+        action_types=TradingStrategyService.ACTION_TYPES,
+        markets=TradingStrategyService.MARKETS,
+    )
+
+
+@strategy_bp.route('/api/list')
+def api_list():
+    """获取策略列表API"""
+    include_inactive = request.args.get('include_inactive', 'false').lower() == 'true'
+    category = request.args.get('category')
+
+    if category:
+        strategies = TradingStrategyService.get_strategies_by_category(category, include_inactive)
+    else:
+        strategies = TradingStrategyService.get_all_strategies(include_inactive)
+
+    return jsonify({
+        'success': True,
+        'strategies': strategies
+    })
+
+
+@strategy_bp.route('/api/<int:strategy_id>')
+def api_get(strategy_id):
+    """获取单个策略API"""
+    strategy = TradingStrategyService.get_strategy(strategy_id)
+    if not strategy:
+        return jsonify({'error': '策略不存在'}), 404
+    return jsonify({'success': True, 'strategy': strategy})
+
+
+@strategy_bp.route('/api/create', methods=['POST'])
+def api_create():
+    """创建策略API"""
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无效的请求数据'}), 400
+
+    # 验证必填字段
+    if not data.get('name'):
+        return jsonify({'error': '策略名称不能为空'}), 400
+    if not data.get('trigger_condition'):
+        return jsonify({'error': '触发条件不能为空'}), 400
+    if not data.get('action_type'):
+        return jsonify({'error': '操作类型不能为空'}), 400
+
+    try:
+        strategy = TradingStrategyService.create_strategy(data)
+        return jsonify({'success': True, 'strategy': strategy})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@strategy_bp.route('/api/<int:strategy_id>', methods=['PUT'])
+def api_update(strategy_id):
+    """更新策略API"""
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无效的请求数据'}), 400
+
+    strategy = TradingStrategyService.update_strategy(strategy_id, data)
+    if not strategy:
+        return jsonify({'error': '策略不存在'}), 404
+
+    return jsonify({'success': True, 'strategy': strategy})
+
+
+@strategy_bp.route('/api/<int:strategy_id>', methods=['DELETE'])
+def api_delete(strategy_id):
+    """删除策略API"""
+    if TradingStrategyService.delete_strategy(strategy_id):
+        return jsonify({'success': True})
+    return jsonify({'error': '策略不存在'}), 404
+
+
+@strategy_bp.route('/api/<int:strategy_id>/toggle', methods=['POST'])
+def api_toggle(strategy_id):
+    """切换策略启用状态API"""
+    strategy = TradingStrategyService.toggle_strategy(strategy_id)
+    if not strategy:
+        return jsonify({'error': '策略不存在'}), 404
+    return jsonify({'success': True, 'strategy': strategy})
+
+
+# 执行记录相关API
+
+@strategy_bp.route('/api/executions')
+def api_executions():
+    """获取执行记录列表API"""
+    strategy_id = request.args.get('strategy_id', type=int)
+    start_date = request.args.get('start_date')
+    end_date = request.args.get('end_date')
+    limit = request.args.get('limit', 50, type=int)
+
+    executions = TradingStrategyService.get_executions(
+        strategy_id=strategy_id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit
+    )
+    return jsonify({'success': True, 'executions': executions})
+
+
+@strategy_bp.route('/api/executions/create', methods=['POST'])
+def api_create_execution():
+    """记录策略执行API"""
+    data = request.get_json()
+    if not data:
+        return jsonify({'error': '无效的请求数据'}), 400
+
+    strategy_id = data.get('strategy_id')
+    if not strategy_id:
+        return jsonify({'error': '策略ID不能为空'}), 400
+
+    try:
+        execution = TradingStrategyService.record_execution(strategy_id, data)
+        if not execution:
+            return jsonify({'error': '策略不存在'}), 404
+        return jsonify({'success': True, 'execution': execution})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@strategy_bp.route('/api/executions/<int:execution_id>', methods=['DELETE'])
+def api_delete_execution(execution_id):
+    """删除执行记录API"""
+    if TradingStrategyService.delete_execution(execution_id):
+        return jsonify({'success': True})
+    return jsonify({'error': '记录不存在'}), 404
+
+
+@strategy_bp.route('/api/statistics')
+def api_statistics():
+    """获取统计信息API"""
+    statistics = TradingStrategyService.get_statistics()
+    return jsonify({'success': True, 'statistics': statistics})

--- a/app/services/trading_strategy.py
+++ b/app/services/trading_strategy.py
@@ -1,0 +1,228 @@
+"""交易策略服务"""
+from datetime import date
+from app import db
+from app.models.trading_strategy import TradingStrategy, StrategyExecution
+
+
+class TradingStrategyService:
+    """交易策略服务类"""
+
+    # 策略分类
+    CATEGORIES = {
+        'index_timing': '指数择时',
+        'sector_rotation': '板块轮动',
+        'arbitrage': '套利策略',
+        'trend_follow': '趋势跟踪',
+        'mean_reversion': '均值回归',
+        'general': '通用策略',
+    }
+
+    # 操作类型
+    ACTION_TYPES = {
+        'buy': '买入',
+        'sell': '卖出',
+        'switch': '换仓',
+        'hold': '持有观望',
+    }
+
+    # 市场类型
+    MARKETS = {
+        'A': 'A股',
+        'US': '美股',
+        'HK': '港股',
+        'ALL': '全市场',
+    }
+
+    @staticmethod
+    def get_all_strategies(include_inactive=False):
+        """获取所有策略"""
+        query = TradingStrategy.query
+        if not include_inactive:
+            query = query.filter_by(is_active=True)
+        strategies = query.order_by(TradingStrategy.priority.desc(), TradingStrategy.id.desc()).all()
+        return [s.to_dict() for s in strategies]
+
+    @staticmethod
+    def get_strategies_by_category(category, include_inactive=False):
+        """按分类获取策略"""
+        query = TradingStrategy.query.filter_by(category=category)
+        if not include_inactive:
+            query = query.filter_by(is_active=True)
+        strategies = query.order_by(TradingStrategy.priority.desc(), TradingStrategy.id.desc()).all()
+        return [s.to_dict() for s in strategies]
+
+    @staticmethod
+    def get_strategy(strategy_id):
+        """获取单个策略"""
+        strategy = TradingStrategy.query.get(strategy_id)
+        return strategy.to_dict() if strategy else None
+
+    @staticmethod
+    def create_strategy(data):
+        """创建新策略"""
+        strategy = TradingStrategy(
+            name=data.get('name'),
+            category=data.get('category', 'general'),
+            trigger_condition=data.get('trigger_condition'),
+            trigger_market=data.get('trigger_market'),
+            trigger_index=data.get('trigger_index'),
+            action_type=data.get('action_type'),
+            sell_target=data.get('sell_target'),
+            buy_target=data.get('buy_target'),
+            description=data.get('description'),
+            notes=data.get('notes'),
+            is_active=data.get('is_active', True),
+            priority=data.get('priority', 0),
+        )
+        db.session.add(strategy)
+        db.session.commit()
+        return strategy.to_dict()
+
+    @staticmethod
+    def update_strategy(strategy_id, data):
+        """更新策略"""
+        strategy = TradingStrategy.query.get(strategy_id)
+        if not strategy:
+            return None
+
+        if 'name' in data:
+            strategy.name = data['name']
+        if 'category' in data:
+            strategy.category = data['category']
+        if 'trigger_condition' in data:
+            strategy.trigger_condition = data['trigger_condition']
+        if 'trigger_market' in data:
+            strategy.trigger_market = data['trigger_market']
+        if 'trigger_index' in data:
+            strategy.trigger_index = data['trigger_index']
+        if 'action_type' in data:
+            strategy.action_type = data['action_type']
+        if 'sell_target' in data:
+            strategy.sell_target = data['sell_target']
+        if 'buy_target' in data:
+            strategy.buy_target = data['buy_target']
+        if 'description' in data:
+            strategy.description = data['description']
+        if 'notes' in data:
+            strategy.notes = data['notes']
+        if 'is_active' in data:
+            strategy.is_active = data['is_active']
+        if 'priority' in data:
+            strategy.priority = data['priority']
+
+        db.session.commit()
+        return strategy.to_dict()
+
+    @staticmethod
+    def delete_strategy(strategy_id):
+        """删除策略"""
+        strategy = TradingStrategy.query.get(strategy_id)
+        if not strategy:
+            return False
+        db.session.delete(strategy)
+        db.session.commit()
+        return True
+
+    @staticmethod
+    def toggle_strategy(strategy_id):
+        """切换策略启用状态"""
+        strategy = TradingStrategy.query.get(strategy_id)
+        if not strategy:
+            return None
+        strategy.is_active = not strategy.is_active
+        db.session.commit()
+        return strategy.to_dict()
+
+    # 执行记录相关方法
+
+    @staticmethod
+    def record_execution(strategy_id, data):
+        """记录策略执行"""
+        strategy = TradingStrategy.query.get(strategy_id)
+        if not strategy:
+            return None
+
+        execution_date = data.get('execution_date')
+        if isinstance(execution_date, str):
+            execution_date = date.fromisoformat(execution_date)
+        elif execution_date is None:
+            execution_date = date.today()
+
+        execution = StrategyExecution(
+            strategy_id=strategy_id,
+            execution_date=execution_date,
+            triggered_by=data.get('triggered_by'),
+            action_taken=data.get('action_taken'),
+            result=data.get('result'),
+            profit_loss=data.get('profit_loss'),
+            notes=data.get('notes'),
+        )
+        db.session.add(execution)
+        db.session.commit()
+        return execution.to_dict()
+
+    @staticmethod
+    def get_executions(strategy_id=None, start_date=None, end_date=None, limit=50):
+        """获取执行记录"""
+        query = StrategyExecution.query
+
+        if strategy_id:
+            query = query.filter_by(strategy_id=strategy_id)
+
+        if start_date:
+            if isinstance(start_date, str):
+                start_date = date.fromisoformat(start_date)
+            query = query.filter(StrategyExecution.execution_date >= start_date)
+
+        if end_date:
+            if isinstance(end_date, str):
+                end_date = date.fromisoformat(end_date)
+            query = query.filter(StrategyExecution.execution_date <= end_date)
+
+        executions = query.order_by(StrategyExecution.execution_date.desc()).limit(limit).all()
+        return [e.to_dict() for e in executions]
+
+    @staticmethod
+    def delete_execution(execution_id):
+        """删除执行记录"""
+        execution = StrategyExecution.query.get(execution_id)
+        if not execution:
+            return False
+        db.session.delete(execution)
+        db.session.commit()
+        return True
+
+    @staticmethod
+    def get_statistics():
+        """获取策略统计信息"""
+        total_strategies = TradingStrategy.query.count()
+        active_strategies = TradingStrategy.query.filter_by(is_active=True).count()
+        total_executions = StrategyExecution.query.count()
+
+        # 按分类统计
+        category_stats = {}
+        for category, name in TradingStrategyService.CATEGORIES.items():
+            count = TradingStrategy.query.filter_by(category=category).count()
+            if count > 0:
+                category_stats[category] = {
+                    'name': name,
+                    'count': count
+                }
+
+        # 按结果统计执行记录
+        result_stats = {}
+        for result in ['success', 'partial', 'skipped']:
+            count = StrategyExecution.query.filter_by(result=result).count()
+            result_stats[result] = count
+
+        # 计算总盈亏
+        total_profit = db.session.query(db.func.sum(StrategyExecution.profit_loss)).scalar() or 0
+
+        return {
+            'total_strategies': total_strategies,
+            'active_strategies': active_strategies,
+            'total_executions': total_executions,
+            'category_stats': category_stats,
+            'result_stats': result_stats,
+            'total_profit': total_profit,
+        }

--- a/app/static/css/trading_strategy.css
+++ b/app/static/css/trading_strategy.css
@@ -1,0 +1,80 @@
+/* 交易策略页面样式 */
+
+/* 统计卡片 */
+.card.text-center .h4 {
+    font-weight: 600;
+}
+
+/* 表格样式 */
+#strategyList tr[data-active="false"] {
+    opacity: 0.6;
+    background-color: #f8f9fa;
+}
+
+#strategyList tr[data-active="false"]:hover {
+    opacity: 0.8;
+}
+
+/* 策略行状态徽章 */
+#strategyList .badge {
+    font-size: 0.75rem;
+}
+
+/* 触发条件文本 */
+.text-truncate {
+    max-width: 250px;
+}
+
+/* 执行记录表格 */
+#executionList .badge {
+    font-size: 0.7rem;
+}
+
+/* 模态框表单 */
+#strategyForm .form-label,
+#executeForm .form-label {
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+#strategyForm .form-text {
+    font-size: 0.75rem;
+}
+
+/* 按钮组 */
+.btn-group-sm .btn {
+    padding: 0.25rem 0.5rem;
+}
+
+/* 分类过滤按钮 */
+.btn-group .btn.active {
+    font-weight: 600;
+}
+
+/* 空状态 */
+#emptyRow td {
+    padding: 2rem 1rem;
+}
+
+#emptyRow i {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+/* 响应式调整 */
+@media (max-width: 768px) {
+    .table th, .table td {
+        font-size: 0.875rem;
+        padding: 0.5rem;
+    }
+
+    .btn-group .btn {
+        font-size: 0.75rem;
+        padding: 0.25rem 0.5rem;
+    }
+
+    .text-truncate {
+        max-width: 150px;
+    }
+}

--- a/app/static/js/trading_strategy.js
+++ b/app/static/js/trading_strategy.js
@@ -1,0 +1,340 @@
+/**
+ * 交易策略页面脚本
+ */
+const StrategyPage = {
+    strategyModal: null,
+    executeModal: null,
+    currentFilter: null,
+    showInactive: false,
+
+    init() {
+        this.strategyModal = new bootstrap.Modal(document.getElementById('strategyModal'));
+        this.executeModal = new bootstrap.Modal(document.getElementById('executeModal'));
+
+        // 设置默认日期为今天
+        document.getElementById('executeDate').value = new Date().toISOString().split('T')[0];
+
+        // 加载执行记录
+        this.loadExecutions();
+    },
+
+    // 显示新增策略模态框
+    showAddModal() {
+        document.getElementById('strategyModalTitle').textContent = '新增策略';
+        document.getElementById('strategyForm').reset();
+        document.getElementById('strategyId').value = '';
+        document.getElementById('strategyCategory').value = 'general';
+        document.getElementById('actionType').value = 'switch';
+        document.getElementById('strategyPriority').value = '0';
+        this.strategyModal.show();
+    },
+
+    // 编辑策略
+    async edit(id) {
+        try {
+            const resp = await fetch(`/strategies/api/${id}`);
+            const data = await resp.json();
+            if (!data.success) {
+                alert(data.error || '获取策略失败');
+                return;
+            }
+
+            const s = data.strategy;
+            document.getElementById('strategyModalTitle').textContent = '编辑策略';
+            document.getElementById('strategyId').value = s.id;
+            document.getElementById('strategyName').value = s.name || '';
+            document.getElementById('strategyCategory').value = s.category || 'general';
+            document.getElementById('triggerMarket').value = s.trigger_market || '';
+            document.getElementById('triggerIndex').value = s.trigger_index || '';
+            document.getElementById('triggerCondition').value = s.trigger_condition || '';
+            document.getElementById('actionType').value = s.action_type || 'switch';
+            document.getElementById('sellTarget').value = s.sell_target || '';
+            document.getElementById('buyTarget').value = s.buy_target || '';
+            document.getElementById('strategyDescription').value = s.description || '';
+            document.getElementById('strategyPriority').value = s.priority || 0;
+            document.getElementById('strategyNotes').value = s.notes || '';
+
+            this.strategyModal.show();
+        } catch (e) {
+            alert('获取策略失败: ' + e.message);
+        }
+    },
+
+    // 保存策略
+    async save() {
+        const id = document.getElementById('strategyId').value;
+        const data = {
+            name: document.getElementById('strategyName').value.trim(),
+            category: document.getElementById('strategyCategory').value,
+            trigger_market: document.getElementById('triggerMarket').value || null,
+            trigger_index: document.getElementById('triggerIndex').value.trim() || null,
+            trigger_condition: document.getElementById('triggerCondition').value.trim(),
+            action_type: document.getElementById('actionType').value,
+            sell_target: document.getElementById('sellTarget').value.trim() || null,
+            buy_target: document.getElementById('buyTarget').value.trim() || null,
+            description: document.getElementById('strategyDescription').value.trim() || null,
+            priority: parseInt(document.getElementById('strategyPriority').value) || 0,
+            notes: document.getElementById('strategyNotes').value.trim() || null,
+        };
+
+        if (!data.name || !data.trigger_condition || !data.action_type) {
+            alert('请填写必填字段');
+            return;
+        }
+
+        try {
+            const url = id ? `/strategies/api/${id}` : '/strategies/api/create';
+            const method = id ? 'PUT' : 'POST';
+
+            const resp = await fetch(url, {
+                method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+
+            const result = await resp.json();
+            if (!result.success) {
+                alert(result.error || '保存失败');
+                return;
+            }
+
+            this.strategyModal.hide();
+            location.reload();
+        } catch (e) {
+            alert('保存失败: ' + e.message);
+        }
+    },
+
+    // 删除策略
+    async delete(id) {
+        if (!confirm('确定要删除这个策略吗？相关的执行记录也会被删除。')) {
+            return;
+        }
+
+        try {
+            const resp = await fetch(`/strategies/api/${id}`, { method: 'DELETE' });
+            const result = await resp.json();
+
+            if (!result.success) {
+                alert(result.error || '删除失败');
+                return;
+            }
+
+            location.reload();
+        } catch (e) {
+            alert('删除失败: ' + e.message);
+        }
+    },
+
+    // 切换启用状态
+    async toggle(id) {
+        try {
+            const resp = await fetch(`/strategies/api/${id}/toggle`, { method: 'POST' });
+            const result = await resp.json();
+
+            if (!result.success) {
+                alert(result.error || '操作失败');
+                return;
+            }
+
+            location.reload();
+        } catch (e) {
+            alert('操作失败: ' + e.message);
+        }
+    },
+
+    // 显示执行记录模态框
+    async execute(id) {
+        try {
+            const resp = await fetch(`/strategies/api/${id}`);
+            const data = await resp.json();
+            if (!data.success) {
+                alert(data.error || '获取策略失败');
+                return;
+            }
+
+            const s = data.strategy;
+            document.getElementById('executeForm').reset();
+            document.getElementById('executeStrategyId').value = s.id;
+            document.getElementById('executeStrategyName').value = s.name;
+            document.getElementById('executeDate').value = new Date().toISOString().split('T')[0];
+            document.getElementById('executeTriggeredBy').value = s.trigger_condition || '';
+            document.getElementById('executeResult').value = 'success';
+
+            this.executeModal.show();
+        } catch (e) {
+            alert('获取策略失败: ' + e.message);
+        }
+    },
+
+    // 保存执行记录
+    async saveExecution() {
+        const data = {
+            strategy_id: parseInt(document.getElementById('executeStrategyId').value),
+            execution_date: document.getElementById('executeDate').value,
+            triggered_by: document.getElementById('executeTriggeredBy').value.trim() || null,
+            action_taken: document.getElementById('executeActionTaken').value.trim() || null,
+            result: document.getElementById('executeResult').value,
+            profit_loss: parseFloat(document.getElementById('executeProfitLoss').value) || null,
+            notes: document.getElementById('executeNotes').value.trim() || null,
+        };
+
+        try {
+            const resp = await fetch('/strategies/api/executions/create', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+
+            const result = await resp.json();
+            if (!result.success) {
+                alert(result.error || '保存失败');
+                return;
+            }
+
+            this.executeModal.hide();
+            this.loadExecutions();
+            this.updateStatistics();
+        } catch (e) {
+            alert('保存失败: ' + e.message);
+        }
+    },
+
+    // 加载执行记录
+    async loadExecutions() {
+        const tbody = document.getElementById('executionList');
+
+        try {
+            const resp = await fetch('/strategies/api/executions?limit=20');
+            const data = await resp.json();
+
+            if (!data.success) {
+                tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">加载失败</td></tr>';
+                return;
+            }
+
+            if (data.executions.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="7" class="text-center text-muted py-3">暂无执行记录</td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = data.executions.map(e => `
+                <tr>
+                    <td>${e.execution_date || '-'}</td>
+                    <td><strong>${e.strategy_name || '-'}</strong></td>
+                    <td class="text-truncate" style="max-width: 150px;" title="${e.triggered_by || ''}">${e.triggered_by || '-'}</td>
+                    <td class="text-truncate" style="max-width: 150px;" title="${e.action_taken || ''}">${e.action_taken || '-'}</td>
+                    <td>
+                        <span class="badge ${e.result === 'success' ? 'bg-success' : e.result === 'partial' ? 'bg-warning' : 'bg-secondary'}">
+                            ${e.result === 'success' ? '成功' : e.result === 'partial' ? '部分' : '跳过'}
+                        </span>
+                    </td>
+                    <td class="${e.profit_loss >= 0 ? 'text-success' : 'text-danger'}">
+                        ${e.profit_loss !== null ? (e.profit_loss >= 0 ? '+' : '') + e.profit_loss.toFixed(2) : '-'}
+                    </td>
+                    <td>
+                        <button class="btn btn-outline-danger btn-sm" onclick="StrategyPage.deleteExecution(${e.id})">
+                            <i class="bi bi-trash"></i>
+                        </button>
+                    </td>
+                </tr>
+            `).join('');
+        } catch (e) {
+            tbody.innerHTML = '<tr><td colspan="7" class="text-center text-danger">加载失败</td></tr>';
+        }
+    },
+
+    // 删除执行记录
+    async deleteExecution(id) {
+        if (!confirm('确定要删除这条执行记录吗？')) {
+            return;
+        }
+
+        try {
+            const resp = await fetch(`/strategies/api/executions/${id}`, { method: 'DELETE' });
+            const result = await resp.json();
+
+            if (!result.success) {
+                alert(result.error || '删除失败');
+                return;
+            }
+
+            this.loadExecutions();
+            this.updateStatistics();
+        } catch (e) {
+            alert('删除失败: ' + e.message);
+        }
+    },
+
+    // 更新统计信息
+    async updateStatistics() {
+        try {
+            const resp = await fetch('/strategies/api/statistics');
+            const data = await resp.json();
+
+            if (data.success) {
+                document.getElementById('stat-total').textContent = data.statistics.total_strategies;
+                document.getElementById('stat-active').textContent = data.statistics.active_strategies;
+                document.getElementById('stat-executions').textContent = data.statistics.total_executions;
+
+                const profitEl = document.getElementById('stat-profit');
+                const profit = data.statistics.total_profit;
+                profitEl.textContent = profit.toFixed(2);
+                profitEl.className = `h4 mb-1 ${profit >= 0 ? 'text-success' : 'text-danger'}`;
+            }
+        } catch (e) {
+            console.error('更新统计失败:', e);
+        }
+    },
+
+    // 按分类过滤
+    filterCategory(category, btn) {
+        this.currentFilter = category;
+
+        // 更新按钮状态
+        document.querySelectorAll('.btn-group .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        this.applyFilter();
+    },
+
+    // 切换显示已禁用
+    toggleInactive() {
+        this.showInactive = document.getElementById('showInactive').checked;
+        this.applyFilter();
+    },
+
+    // 应用过滤
+    applyFilter() {
+        const rows = document.querySelectorAll('#strategyList tr[data-id]');
+
+        rows.forEach(row => {
+            const category = row.dataset.category;
+            const active = row.dataset.active === 'true';
+
+            let show = true;
+
+            // 分类过滤
+            if (this.currentFilter && category !== this.currentFilter) {
+                show = false;
+            }
+
+            // 启用状态过滤
+            if (!this.showInactive && !active) {
+                show = false;
+            }
+
+            row.style.display = show ? '' : 'none';
+        });
+
+        // 显示/隐藏空状态
+        const visibleRows = document.querySelectorAll('#strategyList tr[data-id]:not([style*="display: none"])');
+        const emptyRow = document.getElementById('emptyRow');
+        if (emptyRow) {
+            emptyRow.style.display = visibleRows.length === 0 ? '' : 'none';
+        }
+    }
+};
+
+// 页面加载完成后初始化
+document.addEventListener('DOMContentLoaded', () => StrategyPage.init());

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -38,6 +38,7 @@
                         <li><a class="dropdown-item" href="{{ url_for('profit.overall') }}"><i class="bi bi-pie-chart"></i> 整体收益</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="{{ url_for('rebalance.index') }}"><i class="bi bi-sliders"></i> 仓位配平</a></li>
+                        <li><a class="dropdown-item" href="{{ url_for('strategy.index') }}"><i class="bi bi-lightbulb"></i> 交易策略</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="#" onclick="NotifySettings.show()"><i class="bi bi-send"></i> 推送设置</a></li>
                     </ul>

--- a/app/templates/trading_strategy.html
+++ b/app/templates/trading_strategy.html
@@ -1,0 +1,336 @@
+{% extends "base.html" %}
+
+{% block title %}交易策略{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/trading_strategy.css') }}">
+{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h4 class="mb-0"><i class="bi bi-lightbulb"></i> 交易策略</h4>
+    <button class="btn btn-primary btn-sm" onclick="StrategyPage.showAddModal()">
+        <i class="bi bi-plus-lg"></i> 新增策略
+    </button>
+</div>
+
+<!-- 统计卡片 -->
+<div class="row g-3 mb-4">
+    <div class="col-6 col-md-3">
+        <div class="card text-center h-100">
+            <div class="card-body py-3">
+                <div class="h4 mb-1 text-primary" id="stat-total">{{ statistics.total_strategies }}</div>
+                <div class="small text-muted">总策略数</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card text-center h-100">
+            <div class="card-body py-3">
+                <div class="h4 mb-1 text-success" id="stat-active">{{ statistics.active_strategies }}</div>
+                <div class="small text-muted">启用中</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card text-center h-100">
+            <div class="card-body py-3">
+                <div class="h4 mb-1 text-info" id="stat-executions">{{ statistics.total_executions }}</div>
+                <div class="small text-muted">执行次数</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3">
+        <div class="card text-center h-100">
+            <div class="card-body py-3">
+                <div class="h4 mb-1 {% if statistics.total_profit >= 0 %}text-success{% else %}text-danger{% endif %}" id="stat-profit">
+                    {{ "%.2f"|format(statistics.total_profit) }}
+                </div>
+                <div class="small text-muted">累计盈亏</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 分类过滤 -->
+<div class="mb-3">
+    <div class="btn-group btn-group-sm" role="group">
+        <button type="button" class="btn btn-outline-secondary active" onclick="StrategyPage.filterCategory(null, this)">全部</button>
+        {% for key, name in categories.items() %}
+        <button type="button" class="btn btn-outline-secondary" onclick="StrategyPage.filterCategory('{{ key }}', this)">{{ name }}</button>
+        {% endfor %}
+    </div>
+    <label class="ms-3">
+        <input type="checkbox" id="showInactive" onchange="StrategyPage.toggleInactive()"> 显示已禁用
+    </label>
+</div>
+
+<!-- 策略列表 -->
+<div class="card">
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th style="width: 60px;">状态</th>
+                        <th>策略名称</th>
+                        <th>分类</th>
+                        <th>触发条件</th>
+                        <th>操作建议</th>
+                        <th style="width: 120px;">操作</th>
+                    </tr>
+                </thead>
+                <tbody id="strategyList">
+                    {% for strategy in strategies %}
+                    <tr data-id="{{ strategy.id }}" data-category="{{ strategy.category }}" data-active="{{ strategy.is_active|lower }}">
+                        <td>
+                            <span class="badge {% if strategy.is_active %}bg-success{% else %}bg-secondary{% endif %}"
+                                  style="cursor: pointer;" onclick="StrategyPage.toggle({{ strategy.id }})">
+                                {{ '启用' if strategy.is_active else '禁用' }}
+                            </span>
+                        </td>
+                        <td>
+                            <strong>{{ strategy.name }}</strong>
+                            {% if strategy.priority > 0 %}
+                            <span class="badge bg-warning text-dark ms-1">优先级 {{ strategy.priority }}</span>
+                            {% endif %}
+                            {% if strategy.description %}
+                            <div class="small text-muted mt-1">{{ strategy.description[:50] }}{% if strategy.description|length > 50 %}...{% endif %}</div>
+                            {% endif %}
+                        </td>
+                        <td><span class="badge bg-light text-dark">{{ categories.get(strategy.category, strategy.category) }}</span></td>
+                        <td>
+                            <div class="small">
+                                {% if strategy.trigger_market %}
+                                <span class="text-muted">市场:</span> {{ markets.get(strategy.trigger_market, strategy.trigger_market) }}
+                                {% endif %}
+                                {% if strategy.trigger_index %}
+                                <span class="text-muted ms-2">指数:</span> {{ strategy.trigger_index }}
+                                {% endif %}
+                            </div>
+                            <div class="text-truncate" style="max-width: 250px;" title="{{ strategy.trigger_condition }}">
+                                {{ strategy.trigger_condition }}
+                            </div>
+                        </td>
+                        <td>
+                            <span class="badge
+                                {% if strategy.action_type == 'buy' %}bg-success
+                                {% elif strategy.action_type == 'sell' %}bg-danger
+                                {% elif strategy.action_type == 'switch' %}bg-info
+                                {% else %}bg-secondary{% endif %}">
+                                {{ action_types.get(strategy.action_type, strategy.action_type) }}
+                            </span>
+                            {% if strategy.sell_target %}
+                            <div class="small text-danger mt-1">卖: {{ strategy.sell_target }}</div>
+                            {% endif %}
+                            {% if strategy.buy_target %}
+                            <div class="small text-success mt-1">买: {{ strategy.buy_target }}</div>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <button class="btn btn-outline-primary" onclick="StrategyPage.edit({{ strategy.id }})" title="编辑">
+                                    <i class="bi bi-pencil"></i>
+                                </button>
+                                <button class="btn btn-outline-success" onclick="StrategyPage.execute({{ strategy.id }})" title="记录执行">
+                                    <i class="bi bi-play-fill"></i>
+                                </button>
+                                <button class="btn btn-outline-danger" onclick="StrategyPage.delete({{ strategy.id }})" title="删除">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                    {% else %}
+                    <tr id="emptyRow">
+                        <td colspan="6" class="text-center text-muted py-4">
+                            <i class="bi bi-inbox"></i> 暂无策略，点击右上角"新增策略"添加
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- 执行记录 -->
+<div class="card mt-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <span><i class="bi bi-clock-history"></i> 最近执行记录</span>
+        <button class="btn btn-outline-secondary btn-sm" onclick="StrategyPage.loadExecutions()">
+            <i class="bi bi-arrow-clockwise"></i> 刷新
+        </button>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-sm mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>日期</th>
+                        <th>策略</th>
+                        <th>触发原因</th>
+                        <th>执行操作</th>
+                        <th>结果</th>
+                        <th>盈亏</th>
+                        <th style="width: 50px;"></th>
+                    </tr>
+                </thead>
+                <tbody id="executionList">
+                    <tr>
+                        <td colspan="7" class="text-center text-muted py-3">加载中...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- 新增/编辑策略模态框 -->
+<div class="modal fade" id="strategyModal" tabindex="-1">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="strategyModalTitle">新增策略</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="strategyForm">
+                    <input type="hidden" id="strategyId">
+                    <div class="row g-3">
+                        <div class="col-md-8">
+                            <label class="form-label">策略名称 *</label>
+                            <input type="text" class="form-control" id="strategyName" required placeholder="例如：纳指透支换仓策略">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">分类</label>
+                            <select class="form-select" id="strategyCategory">
+                                {% for key, name in categories.items() %}
+                                <option value="{{ key }}">{{ name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">触发市场</label>
+                            <select class="form-select" id="triggerMarket">
+                                <option value="">不限</option>
+                                {% for key, name in markets.items() %}
+                                <option value="{{ key }}">{{ name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">触发指数代码</label>
+                            <input type="text" class="form-control" id="triggerIndex" placeholder="例如：NDX, SPX">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">触发条件 *</label>
+                            <textarea class="form-control" id="triggerCondition" rows="2" required
+                                      placeholder="例如：当纳指提前透支晚上涨幅（日内涨幅超过预期）"></textarea>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">操作类型 *</label>
+                            <select class="form-select" id="actionType" required>
+                                {% for key, name in action_types.items() %}
+                                <option value="{{ key }}">{{ name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">卖出标的</label>
+                            <input type="text" class="form-control" id="sellTarget" placeholder="股票代码，多个用逗号分隔">
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">买入标的</label>
+                            <input type="text" class="form-control" id="buyTarget" placeholder="例如：达链, 谷歌链">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label">详细说明</label>
+                            <textarea class="form-control" id="strategyDescription" rows="2"
+                                      placeholder="策略的详细逻辑和注意事项"></textarea>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">优先级</label>
+                            <input type="number" class="form-control" id="strategyPriority" value="0" min="0">
+                            <div class="form-text">数值越大优先级越高</div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">备注</label>
+                            <input type="text" class="form-control" id="strategyNotes" placeholder="可选备注">
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" class="btn btn-primary" onclick="StrategyPage.save()">保存</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 记录执行模态框 -->
+<div class="modal fade" id="executeModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">记录策略执行</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="executeForm">
+                    <input type="hidden" id="executeStrategyId">
+                    <div class="mb-3">
+                        <label class="form-label">策略名称</label>
+                        <input type="text" class="form-control" id="executeStrategyName" readonly>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">执行日期</label>
+                        <input type="date" class="form-control" id="executeDate">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">触发原因</label>
+                        <input type="text" class="form-control" id="executeTriggeredBy" placeholder="是什么触发了此次执行">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">实际操作</label>
+                        <textarea class="form-control" id="executeActionTaken" rows="2" placeholder="实际执行了什么操作"></textarea>
+                    </div>
+                    <div class="row">
+                        <div class="col-6">
+                            <label class="form-label">执行结果</label>
+                            <select class="form-select" id="executeResult">
+                                <option value="success">成功</option>
+                                <option value="partial">部分执行</option>
+                                <option value="skipped">跳过</option>
+                            </select>
+                        </div>
+                        <div class="col-6">
+                            <label class="form-label">盈亏金额</label>
+                            <input type="number" class="form-control" id="executeProfitLoss" step="0.01" placeholder="正为盈利">
+                        </div>
+                    </div>
+                    <div class="mt-3">
+                        <label class="form-label">备注</label>
+                        <input type="text" class="form-control" id="executeNotes" placeholder="可选备注">
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" class="btn btn-primary" onclick="StrategyPage.saveExecution()">保存</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+<script>
+const CATEGORIES = {{ categories | tojson }};
+const ACTION_TYPES = {{ action_types | tojson }};
+const MARKETS = {{ markets | tojson }};
+</script>
+<script src="{{ url_for('static', filename='js/trading_strategy.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
新增交易策略管理功能，支持：
- 创建/编辑/删除交易策略
- 策略分类（指数择时、板块轮动、套利策略等）
- 触发条件和操作建议（买入/卖出/换仓）
- 策略执行记录和盈亏统计
- 策略启用/禁用切换

示例策略：当纳指提前透支晚上涨幅，可以先卖出，买入达链或谷歌链

https://claude.ai/code/session_01AxToLVbHJkavPRQA9zpZyE