### PR TITLE
移动交易策略到导航栏并在走势看板添加持仓分类

### DIFF
--- a/app/config/stock_codes.py
+++ b/app/config/stock_codes.py
@@ -59,5 +59,6 @@ CATEGORY_NAMES = {
     'storage': '存储',
     'pcb': 'PCB',
     'cpu': 'CPU',
+    'positions': '持仓',
     'custom': '自定义'
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,7 @@
                 <a class="nav-link" href="{{ url_for('briefing.index') }}">每日简报</a>
                 <a class="nav-link" href="{{ url_for('alert.index') }}">预警</a>
                 <a class="nav-link" href="{{ url_for('heavy_metals.index') }}">走势看板</a>
+                <a class="nav-link" href="{{ url_for('strategy.index') }}">交易策略</a>
                 <a class="nav-link" href="{{ url_for('stock.manage') }}">股票代码管理</a>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
@@ -38,7 +39,6 @@
                         <li><a class="dropdown-item" href="{{ url_for('profit.overall') }}"><i class="bi bi-pie-chart"></i> 整体收益</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="{{ url_for('rebalance.index') }}"><i class="bi bi-sliders"></i> 仓位配平</a></li>
-                        <li><a class="dropdown-item" href="{{ url_for('strategy.index') }}"><i class="bi bi-lightbulb"></i> 交易策略</a></li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" href="#" onclick="NotifySettings.show()"><i class="bi bi-send"></i> 推送设置</a></li>
                     </ul>

--- a/app/templates/heavy_metals.html
+++ b/app/templates/heavy_metals.html
@@ -443,6 +443,7 @@
             <option value="etf">ETF</option>
             <option value="storage">存储</option>
             <option value="pcb">PCB</option>
+            <option value="positions">持仓</option>
             <option value="custom">自定义</option>
         </select>
     </div>


### PR DESCRIPTION
- 将交易策略从"我的"下拉菜单移动到主导航栏（股票代码管理左侧）
- 在走势看板添加"持仓"分类选项，显示当前持仓股票的走势

https://claude.ai/code/session_01Km6BbMY5ZBZVm3BmCgHn4D