### PR TITLE
添加默认交易策略：均线突破策略

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -197,6 +197,10 @@ def create_app(config_class=None):
         migrate_daily_snapshot_table()
         migrate_trades_table()
 
+        # 初始化默认交易策略
+        from app.services.trading_strategy import TradingStrategyService
+        TradingStrategyService.init_default_strategies()
+
     # 预加载 OCR 模型，避免首次识别时卡顿
     from app.services.ocr import preload_model
     preload_model()

--- a/app/services/trading_strategy.py
+++ b/app/services/trading_strategy.py
@@ -193,6 +193,44 @@ class TradingStrategyService:
         return True
 
     @staticmethod
+    def init_default_strategies():
+        """初始化默认交易策略
+
+        如果数据库中没有默认策略，则创建它们。
+        """
+        # 默认策略列表
+        default_strategies = [
+            {
+                'name': '均线突破策略',
+                'category': 'trend_follow',
+                'trigger_condition': '5日线偏离卖出，10日线回踩买入',
+                'trigger_market': 'ALL',
+                'trigger_index': None,
+                'action_type': 'switch',
+                'sell_target': None,
+                'buy_target': None,
+                'description': '当股价向上偏离5日均线较多时，说明短期涨幅过大，可以考虑先卖出锁定利润；当股价回调至10日均线附近获得支撑时，是较好的买入时机。',
+                'notes': '适用于震荡上行的市场环境，需结合成交量判断。',
+                'is_active': True,
+                'priority': 10,
+            },
+        ]
+
+        created_count = 0
+        for strategy_data in default_strategies:
+            # 检查是否已存在同名策略
+            existing = TradingStrategy.query.filter_by(name=strategy_data['name']).first()
+            if not existing:
+                strategy = TradingStrategy(**strategy_data)
+                db.session.add(strategy)
+                created_count += 1
+
+        if created_count > 0:
+            db.session.commit()
+
+        return created_count
+
+    @staticmethod
     def get_statistics():
         """获取策略统计信息"""
         total_strategies = TradingStrategy.query.count()


### PR DESCRIPTION
- 新增 TradingStrategyService.init_default_strategies() 方法
- 应用启动时自动初始化默认策略
- 默认策略：5日线偏离卖出，10日线回踩买入

https://claude.ai/code/session_01JL361SH3bH95Nu1xkhCjsB