### PR TITLE
调整A股数据源优先级：提高腾讯，降低东方财富

### DIFF
--- a/app/config/data_sources.py
+++ b/app/config/data_sources.py
@@ -18,9 +18,9 @@ MARKET_DATA_SOURCES = {
         'sources': ['sina', 'tencent', 'eastmoney'],
         'fallback': 'yfinance',
         'weights': {
-            'sina': 40,      # 新浪财经 - 稳定性较好
-            'tencent': 35,   # 腾讯财经 - 批量获取效率高
-            'eastmoney': 25  # 东方财富 - 降为最后备选
+            'sina': 35,      # 新浪财经 - 稳定性较好
+            'tencent': 45,   # 腾讯财经 - 批量获取效率高，优先使用
+            'eastmoney': 20  # 东方财富 - 最后备选
         },
         'description': 'A股市场使用国内数据源，yfinance作为兜底'
     },

--- a/app/services/load_balancer.py
+++ b/app/services/load_balancer.py
@@ -19,7 +19,7 @@ MARKET_SOURCES = {
     'A': {
         'sources': ['sina', 'tencent', 'eastmoney'],
         'fallback': 'yfinance',
-        'weights': {'sina': 40, 'tencent': 35, 'eastmoney': 25},  # 初始权重
+        'weights': {'sina': 35, 'tencent': 45, 'eastmoney': 20},  # 初始权重：腾讯优先
     },
     'US': {
         'sources': ['yfinance', 'twelvedata', 'polygon'],


### PR DESCRIPTION
- 腾讯财经权重: 35 → 45 (最高优先级)
- 新浪财经权重: 40 → 35
- 东方财富权重: 25 → 20 (最低优先级)

https://claude.ai/code/session_019xFAz3f8tMPmLJSJtAVm2n