### PR TITLE
修复简报页面台股数据获取失败的问题

### DIFF
--- a/app/services/briefing.py
+++ b/app/services/briefing.py
@@ -97,7 +97,8 @@ class BriefingService:
     def get_stocks_basic_data(force_refresh: bool = False) -> dict:
         """获取基础股票数据（价格+投资建议，不含PE和财报）
 
-        使用缓存的收盘价数据，不发起实时API请求。
+        当 force_refresh=False 时，使用缓存的收盘价数据，不发起实时API请求。
+        当 force_refresh=True 时，从API获取数据并缓存。
         """
         from app.services.unified_stock_data import unified_stock_data_service
 
@@ -109,8 +110,13 @@ class BriefingService:
 
         prices = {}
         try:
-            # 使用缓存的收盘价，不发起实时API请求
-            prices = unified_stock_data_service.get_closing_prices(stock_codes)
+            if force_refresh:
+                # 强制刷新：从API获取实时数据并缓存
+                # get_realtime_prices 返回 {stock_code: data_dict} 格式
+                prices = unified_stock_data_service.get_realtime_prices(stock_codes, force_refresh=True)
+            else:
+                # 使用缓存的收盘价，不发起实时API请求
+                prices = unified_stock_data_service.get_closing_prices(stock_codes)
         except Exception as e:
             logger.error(f"获取股票价格失败: {e}")
 


### PR DESCRIPTION
问题：欣兴电子(3037.TW)等台股显示"数据获取失败"
原因：get_stocks_basic_data函数的force_refresh参数被忽略，
     始终只从缓存读取，导致从未缓存的股票无法获取数据

修复：当force_refresh=True时，调用get_realtime_prices从API
     获取数据并缓存，使台股、韩股等非A股也能正常获取数据

https://claude.ai/code/session_019M3waTDoLLjqWviW5fU1bt