### PR TITLE
fix: 添加对美股指数代码(^前缀)的市场识别支持

### DIFF
--- a/app/utils/market_identifier.py
+++ b/app/utils/market_identifier.py
@@ -53,6 +53,10 @@ class MarketIdentifier:
         if code.upper().endswith('.KS'):
             return 'KR'
 
+        # 美股指数：以^开头（如 ^GSPC, ^DJI, ^IXIC, ^VIX）
+        if code.startswith('^'):
+            return 'US'
+
         # A股：6位纯数字，或数字开头带.SS/.SZ后缀
         if code.isdigit() and len(code) == 6:
             return 'A'


### PR DESCRIPTION
修复 MarketIdentifier.identify() 无法识别 ^GSPC 等以 ^ 开头的 美股指数代码的问题。这些代码现在正确返回 'US' 市场类型。

示例：^GSPC (S&P 500), ^DJI (道琼斯), ^IXIC (纳斯达克), ^VIX

https://claude.ai/code/session_014qmiaDYZYzi5DyJDFbj6F5