### PR TITLE
fix: 修复预警信号类型切换无效的问题

### DIFF
--- a/app/static/js/alert-page.js
+++ b/app/static/js/alert-page.js
@@ -445,7 +445,7 @@ const AlertPage = {
             btn.classList.add('active');
 
             this.filter.signalType = btn.dataset.type;
-            this.renderAlerts();
+            this.render();
         });
 
         // 设置弹窗滑块变化
@@ -1433,7 +1433,7 @@ const AlertPage = {
 
         // 重新评估并渲染
         this.evaluateAlerts();
-        this.renderAlerts();
+        this.render();
     },
 
     /**


### PR DESCRIPTION
renderAlerts() 方法不存在，改为调用 render() 方法

https://claude.ai/code/session_01D4m9eHEcnDiJXMrVoypQ7e