### PR TITLE
优化预警页面：隐藏没有信号的股票卡片

### DIFF
--- a/app/static/js/alert-page.js
+++ b/app/static/js/alert-page.js
@@ -723,10 +723,23 @@ const AlertPage = {
 
             if (totalCount >= MAX_STOCKS) break;
 
+            // 应用信号类型过滤
+            const stockAlerts = this.data.alerts[stock.code] || [];
+            let filteredAlerts = stockAlerts;
+            if (this.filter.signalType !== 'all') {
+                filteredAlerts = stockAlerts.filter(a => a.type === this.filter.signalType);
+            }
+
+            // 只显示有信号的股票
+            if (filteredAlerts.length === 0) continue;
+
             if (!categoryStocks[catId]) {
                 categoryStocks[catId] = [];
             }
-            categoryStocks[catId].push(stock);
+            categoryStocks[catId].push({
+                ...stock,
+                alerts: filteredAlerts
+            });
             totalCount++;
         }
 
@@ -1015,6 +1028,9 @@ const AlertPage = {
             if (this.filter.signalType !== 'all') {
                 filteredAlerts = stockAlerts.filter(a => a.type === this.filter.signalType);
             }
+
+            // 只显示有信号的股票卡片
+            if (filteredAlerts.length === 0) continue;
 
             categoryData[catId].stocks.push({
                 ...stock,


### PR DESCRIPTION
- 卡片视图：只显示有匹配信号的股票卡片
- 列表视图：同样应用信号过滤，只显示有信号的股票
- 支持信号类型筛选（全部/买入/卖出/中性）

https://claude.ai/code/session_01W7rbPo3ZZFno4wFLrC79n4