### PR TITLE
添加 /wyckoff/auto 路由并传递 positions 参数

### DIFF
--- a/app/routes/wyckoff.py
+++ b/app/routes/wyckoff.py
@@ -6,6 +6,17 @@ from app.services.backtest import BacktestService
 from app.services.position import PositionService
 
 
+@wyckoff_bp.route('/auto')
+def auto_index():
+    """威科夫自动分析页面"""
+    latest_date = PositionService.get_latest_date()
+    positions = []
+    if latest_date:
+        position_list = PositionService.get_snapshot(latest_date)
+        positions = [{'code': p.stock_code, 'name': p.stock_name} for p in position_list]
+    return render_template('wyckoff_auto.html', positions=positions)
+
+
 # 参考图路由
 @wyckoff_bp.route('/reference')
 def reference_list():


### PR DESCRIPTION
修复渲染 wyckoff_auto.html 模板时因缺少 positions 变量导致的
TypeError: Object of type Undefined is not JSON serializable 错误。

Slack thread: https://gsstockco.slack.com/archives/C0ADZUWME49/p1771076363832089

https://claude.ai/code/session_014CHdjkoagoHr4b42Yps2Fi