### PR TITLE
重构AI分析UI - 点击股票卡片显示AI分析弹窗和历史记录

### DIFF
--- a/app/routes/briefing.py
+++ b/app/routes/briefing.py
@@ -1,5 +1,6 @@
 """每日简报路由 - 渐进式加载"""
 import logging
+from datetime import date, timedelta
 from flask import render_template, jsonify, request
 from app.routes import briefing_bp
 from app.services.briefing import BriefingService
@@ -132,6 +133,46 @@ def ai_status():
     """AI分析功能状态"""
     from app.services.ai_analyzer import AIAnalyzerService
     return jsonify({'enabled': AIAnalyzerService.is_available()})
+
+
+@briefing_bp.route('/api/ai/history')
+def ai_history():
+    """获取股票AI分析历史"""
+    from app.models.unified_cache import UnifiedStockCache
+
+    stock_code = request.args.get('stock_code', '')
+    if not stock_code:
+        return jsonify({'error': '缺少 stock_code'}), 400
+
+    try:
+        # 获取最近30天的AI分析记录
+        today = date.today()
+        history = []
+
+        # 查询该股票的所有AI分析缓存记录
+        caches = UnifiedStockCache.query.filter(
+            UnifiedStockCache.stock_code == stock_code,
+            UnifiedStockCache.cache_type == 'ai_analysis',
+            UnifiedStockCache.cache_date >= today - timedelta(days=30)
+        ).order_by(UnifiedStockCache.cache_date.desc()).limit(10).all()
+
+        for cache in caches:
+            data = cache.get_data()
+            if data and isinstance(data, dict) and 'error' not in data:
+                history.append({
+                    'date': cache.cache_date.strftime('%Y-%m-%d'),
+                    'signal': data.get('signal'),
+                    'score': data.get('score'),
+                    'conclusion': data.get('conclusion'),
+                    'confidence': data.get('confidence'),
+                    'analysis': data.get('analysis'),
+                    'action_plan': data.get('action_plan'),
+                })
+
+        return jsonify({'history': history})
+    except Exception as e:
+        logger.error(f"获取AI历史失败: {e}", exc_info=True)
+        return jsonify({'error': str(e)}), 500
 
 
 @briefing_bp.route('/api/ai/analyze', methods=['POST'])

--- a/app/static/js/briefing.js
+++ b/app/static/js/briefing.js
@@ -7,10 +7,12 @@ class BriefingPage {
     static technicalData = null;
     static stocksRendered = false;
     static aiEnabled = false;
+    static currentStock = null;  // 当前选中的股票 {code, name}
 
     static init() {
         this.bindAdviceEvents();
-        this.bindAIEvents();
+        this.bindCardClickEvents();
+        this.bindModalEvents();
         this.checkAIStatus();
 
         document.getElementById('dataContent').classList.remove('d-none');
@@ -91,61 +93,146 @@ class BriefingPage {
             const resp = await fetch('/briefing/api/ai/status');
             const data = await resp.json();
             this.aiEnabled = data.enabled;
-            if (this.aiEnabled) {
-                document.querySelectorAll('.bc-ai').forEach(el => el.classList.remove('d-none'));
+            // 如果股票已渲染，重新添加clickable类
+            if (this.aiEnabled && this.stocksRendered) {
+                document.querySelectorAll('.briefing-card[data-code]').forEach(el => {
+                    el.classList.add('clickable');
+                });
             }
         } catch (e) {
             console.error('检查AI状态失败:', e);
         }
     }
 
-    static bindAIEvents() {
+    static bindCardClickEvents() {
         document.addEventListener('click', (e) => {
-            const btn = e.target.closest('.bc-ai-btn');
-            if (!btn) return;
-            e.stopPropagation();
-            const container = btn.closest('.bc-ai');
-            const code = container.dataset.code;
-            const name = container.dataset.name;
+            const card = e.target.closest('.briefing-card.clickable');
+            if (!card) return;
+            // 不拦截建议图标点击
+            if (e.target.classList.contains('advice-icon-btn')) return;
 
-            const existingResult = container.querySelector('.bc-ai-result');
-            if (existingResult) {
-                existingResult.remove();
-                return;
+            const code = card.dataset.code;
+            const name = card.dataset.name;
+            if (code && this.aiEnabled) {
+                this.openAIModal(code, name);
             }
-
-            this.fetchAIAnalysis(btn, container, code, name);
         });
     }
 
-    static async fetchAIAnalysis(btn, container, code, name) {
+    static bindModalEvents() {
+        // 点击背景关闭模态框
+        document.getElementById('aiModal')?.addEventListener('click', (e) => {
+            if (e.target.classList.contains('ai-modal-overlay')) {
+                this.closeAIModal();
+            }
+        });
+        // ESC键关闭
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') {
+                this.closeAIModal();
+            }
+        });
+    }
+
+    static openAIModal(code, name) {
+        this.currentStock = {code, name};
+        document.getElementById('aiModalTitle').textContent = name || code;
+        document.getElementById('aiModalSubtitle').textContent = code;
+        document.getElementById('aiResultPanel').innerHTML = '';
+        document.getElementById('aiHistoryList').innerHTML = '<div class="ai-history-empty">加载中...</div>';
+        document.getElementById('aiModal').classList.remove('d-none');
+        document.body.style.overflow = 'hidden';
+
+        // 加载历史记录
+        this.loadAIHistory(code);
+    }
+
+    static closeAIModal() {
+        document.getElementById('aiModal').classList.add('d-none');
+        document.body.style.overflow = '';
+        this.currentStock = null;
+    }
+
+    static async loadAIHistory(code) {
+        try {
+            const resp = await fetch(`/briefing/api/ai/history?stock_code=${encodeURIComponent(code)}`);
+            const data = await resp.json();
+            if (data.error) throw new Error(data.error);
+            this.renderAIHistory(data.history || []);
+        } catch (e) {
+            console.error('加载AI历史失败:', e);
+            document.getElementById('aiHistoryList').innerHTML =
+                '<div class="ai-history-empty">加载历史记录失败</div>';
+        }
+    }
+
+    static renderAIHistory(history) {
+        const container = document.getElementById('aiHistoryList');
+        if (!history || history.length === 0) {
+            container.innerHTML = '<div class="ai-history-empty">暂无历史分析记录</div>';
+            return;
+        }
+
+        const signalMap = {
+            'STRONG_BUY': {text: '强烈买入', bg: '#28a745'},
+            'BUY': {text: '买入', bg: '#20c997'},
+            'HOLD': {text: '持有', bg: '#ffc107'},
+            'SELL': {text: '卖出', bg: '#fd7e14'},
+            'STRONG_SELL': {text: '强烈卖出', bg: '#dc3545'}
+        };
+
+        container.innerHTML = history.map((item, idx) => {
+            const sig = signalMap[item.signal] || {text: item.signal || '--', bg: '#6c757d'};
+            return `
+                <div class="ai-history-item" onclick="BriefingPage.showHistoryDetail(${idx})">
+                    <div class="ai-history-item-header">
+                        <span class="ai-history-date">${item.date}</span>
+                        <span class="ai-history-signal" style="background:${sig.bg}">${sig.text}</span>
+                    </div>
+                    <div class="ai-history-conclusion">${item.conclusion || '--'}</div>
+                </div>
+            `;
+        }).join('');
+
+        // 存储历史数据供详情展示
+        this._historyData = history;
+    }
+
+    static showHistoryDetail(idx) {
+        if (!this._historyData || !this._historyData[idx]) return;
+        this.renderAIResultPanel(this._historyData[idx], true);
+    }
+
+    static async runAIAnalysis() {
+        if (!this.currentStock) return;
+        const {code, name} = this.currentStock;
+        const btn = document.getElementById('aiAnalyzeBtn');
+
         btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" style="width:10px;height:10px"></span>';
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm"></span> 分析中...';
 
         try {
             const resp = await fetch('/briefing/api/ai/analyze', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({stock_code: code, stock_name: name})
+                body: JSON.stringify({stock_code: code, stock_name: name, force: true})
             });
             const result = await resp.json();
             if (result.error) throw new Error(result.error);
-            this.renderAIResult(container, result);
+            this.renderAIResultPanel(result);
+            // 刷新历史
+            this.loadAIHistory(code);
         } catch (e) {
             console.error(`AI分析 ${code} 失败:`, e);
-            const errDiv = document.createElement('div');
-            errDiv.className = 'bc-ai-result';
-            errDiv.innerHTML = `<span style="color:#dc3545">分析失败: ${e.message}</span>`;
-            container.appendChild(errDiv);
+            document.getElementById('aiResultPanel').innerHTML =
+                `<div class="ai-result-panel" style="color:#dc3545">分析失败: ${e.message}</div>`;
         } finally {
             btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-robot"></i> AI';
+            btn.innerHTML = '<i class="bi bi-robot"></i> AI智能分析';
         }
     }
 
-    static renderAIResult(container, result) {
-        container.querySelector('.bc-ai-result')?.remove();
-
+    static renderAIResultPanel(result, isHistory = false) {
         const signalMap = {
             'STRONG_BUY': {text: '强烈买入', bg: '#28a745'},
             'BUY': {text: '买入', bg: '#20c997'},
@@ -158,29 +245,33 @@ class BriefingPage {
         const analysis = result.analysis || {};
         const plan = result.action_plan || {};
 
-        let html = `<div class="bc-ai-result">`;
-        html += `<div style="margin-bottom:4px"><span class="bc-ai-signal" style="background:${sig.bg};color:#fff">${sig.text}</span>`;
-        if (result.score !== undefined) html += ` <span style="font-weight:600">${result.score}分</span>`;
-        if (result.from_cache) html += ` <span style="color:#aaa;font-size:0.6rem">缓存</span>`;
+        let html = `<div class="ai-result-panel">`;
+        if (isHistory && result.date) {
+            html += `<div style="color:#888;font-size:0.75rem;margin-bottom:8px">${result.date} 的分析</div>`;
+        }
+        html += `<div class="ai-result-header">`;
+        html += `<span class="ai-signal-badge" style="background:${sig.bg}">${sig.text}</span>`;
+        if (result.score !== undefined) html += `<span class="ai-score">${result.score}分</span>`;
+        if (result.from_cache && !isHistory) html += `<span class="ai-cache-tag">缓存</span>`;
         html += `</div>`;
 
-        if (result.conclusion) html += `<div style="margin-bottom:4px;font-weight:500">${result.conclusion}</div>`;
+        if (result.conclusion) html += `<div class="ai-conclusion">${result.conclusion}</div>`;
 
         const details = [];
         if (analysis.trend) details.push(`趋势: ${analysis.trend}`);
         if (analysis.volume) details.push(`量能: ${analysis.volume}`);
         if (analysis.risk) details.push(`风险: ${analysis.risk}`);
-        if (details.length) html += `<div style="color:#666;margin-bottom:4px">${details.join(' | ')}</div>`;
+        if (details.length) html += `<div class="ai-details">${details.join('<br>')}</div>`;
 
         const planItems = [];
-        if (plan.buy_price) planItems.push(`买入:${plan.buy_price}`);
-        if (plan.stop_loss) planItems.push(`止损:${plan.stop_loss}`);
-        if (plan.target_price) planItems.push(`目标:${plan.target_price}`);
-        if (planItems.length) html += `<div style="color:#888">${planItems.join(' | ')}</div>`;
-        if (plan.position_advice) html += `<div style="color:#888">${plan.position_advice}</div>`;
+        if (plan.buy_price) planItems.push(`买入价: ${plan.buy_price}`);
+        if (plan.stop_loss) planItems.push(`止损价: ${plan.stop_loss}`);
+        if (plan.target_price) planItems.push(`目标价: ${plan.target_price}`);
+        if (planItems.length) html += `<div class="ai-action-plan">${planItems.join(' | ')}</div>`;
+        if (plan.position_advice) html += `<div class="ai-action-plan">${plan.position_advice}</div>`;
 
         html += `</div>`;
-        container.insertAdjacentHTML('beforeend', html);
+        document.getElementById('aiResultPanel').innerHTML = html;
     }
 
     // ========== 数据加载 ==========
@@ -513,8 +604,14 @@ class BriefingPage {
             ? `<i class="bi bi-journal-text advice-icon-btn" data-advice="${this.escapeHtml(stock.investment_advice)}" title="查看投资建议"></i>`
             : '';
 
+        // 如果AI已启用且无错误，添加clickable类和数据属性
+        const clickableClass = !stock.error && this.aiEnabled ? 'clickable' : '';
+        const dataAttrs = !stock.error && this.aiEnabled
+            ? `data-code="${stock.code}" data-name="${stock.name}"`
+            : '';
+
         return `
-            <div class="briefing-card ${stock.error ? 'has-error' : ''}">
+            <div class="briefing-card ${stock.error ? 'has-error' : ''} ${clickableClass}" ${dataAttrs}>
                 <div class="bc-header">
                     <div>
                         <div class="bc-name">${stock.name}</div>
@@ -534,9 +631,6 @@ class BriefingPage {
                     <div class="bc-secondary">
                         ${stock.market !== 'A' ? `<span class="stock-pe" data-code="${stock.code}"></span>` : ''}
                         <span class="stock-earnings" data-code="${stock.code}"></span>
-                    </div>
-                    <div class="bc-ai ${this.aiEnabled ? '' : 'd-none'}" data-code="${stock.code}" data-name="${stock.name}">
-                        <button class="bc-ai-btn" title="AI分析"><i class="bi bi-robot"></i> AI</button>
                     </div>
                 `}
             </div>

--- a/app/templates/briefing.html
+++ b/app/templates/briefing.html
@@ -285,29 +285,214 @@
         font-weight: 500;
     }
 
-    /* AI分析按钮 */
-    .bc-ai { margin-top: 4px; }
-    .bc-ai-btn {
-        border: 1px solid #6f42c1; color: #6f42c1; background: transparent;
-        font-size: 0.65rem; padding: 1px 6px; border-radius: 3px; cursor: pointer;
+    /* 可点击卡片 */
+    .briefing-card.clickable {
+        cursor: pointer;
+        transition: box-shadow 0.2s, transform 0.1s;
     }
-    .bc-ai-btn:hover { background: #6f42c1; color: #fff; }
-    .bc-ai-btn:disabled { opacity: 0.6; cursor: wait; }
+    .briefing-card.clickable:hover {
+        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+        transform: translateY(-1px);
+    }
+    .briefing-card.clickable:active {
+        transform: translateY(0);
+    }
+
+    /* AI分析模态框 */
+    .ai-modal-overlay {
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: rgba(0,0,0,0.5);
+        z-index: 1040;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .ai-modal {
+        background: #fff;
+        border-radius: 12px;
+        width: 90%;
+        max-width: 500px;
+        max-height: 80vh;
+        overflow: hidden;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.25);
+    }
+    .ai-modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 20px;
+        background: #f8f9fa;
+        border-bottom: 1px solid #dee2e6;
+    }
+    .ai-modal-title {
+        font-size: 1rem;
+        font-weight: 600;
+        margin: 0;
+    }
+    .ai-modal-subtitle {
+        font-size: 0.75rem;
+        color: #888;
+        margin-top: 2px;
+    }
+    .ai-modal-close {
+        border: none;
+        background: none;
+        font-size: 1.5rem;
+        color: #6c757d;
+        cursor: pointer;
+        line-height: 1;
+    }
+    .ai-modal-close:hover { color: #333; }
+    .ai-modal-body {
+        padding: 20px;
+        overflow-y: auto;
+        max-height: calc(80vh - 120px);
+    }
+
+    /* AI分析按钮 */
+    .ai-modal-btn {
+        width: 100%;
+        padding: 12px 16px;
+        border: 2px solid #6f42c1;
+        color: #6f42c1;
+        background: transparent;
+        font-size: 0.95rem;
+        font-weight: 600;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.2s;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+    }
+    .ai-modal-btn:hover { background: #6f42c1; color: #fff; }
+    .ai-modal-btn:disabled { opacity: 0.6; cursor: wait; }
 
     /* AI分析结果面板 */
-    .bc-ai-result {
-        margin-top: 6px; padding: 6px 8px;
-        background: #f8f7fc; border-radius: 4px; border: 1px solid #e8e0f0;
-        font-size: 0.72rem; line-height: 1.5;
+    .ai-result-panel {
+        margin-top: 16px;
+        padding: 16px;
+        background: #f8f7fc;
+        border-radius: 8px;
+        border: 1px solid #e8e0f0;
     }
-    .bc-ai-signal {
-        display: inline-block; padding: 1px 6px; border-radius: 3px;
-        font-weight: 600; font-size: 0.65rem;
+    .ai-result-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+    .ai-signal-badge {
+        display: inline-block;
+        padding: 4px 12px;
+        border-radius: 4px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: #fff;
+    }
+    .ai-score {
+        font-weight: 600;
+        font-size: 0.9rem;
+    }
+    .ai-cache-tag {
+        font-size: 0.7rem;
+        color: #aaa;
+    }
+    .ai-conclusion {
+        font-weight: 500;
+        margin-bottom: 8px;
+        font-size: 0.9rem;
+    }
+    .ai-details {
+        color: #666;
+        font-size: 0.8rem;
+        margin-bottom: 8px;
+    }
+    .ai-action-plan {
+        color: #888;
+        font-size: 0.8rem;
+    }
+
+    /* AI历史记录 */
+    .ai-history-section {
+        margin-top: 20px;
+        border-top: 1px solid #eee;
+        padding-top: 16px;
+    }
+    .ai-history-title {
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #666;
+        margin-bottom: 12px;
+    }
+    .ai-history-empty {
+        color: #aaa;
+        font-size: 0.8rem;
+        text-align: center;
+        padding: 16px;
+    }
+    .ai-history-item {
+        padding: 10px 12px;
+        border: 1px solid #e8e0f0;
+        border-radius: 6px;
+        margin-bottom: 8px;
+        cursor: pointer;
+        transition: background 0.2s;
+    }
+    .ai-history-item:hover {
+        background: #f8f7fc;
+    }
+    .ai-history-item-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 4px;
+    }
+    .ai-history-date {
+        font-size: 0.75rem;
+        color: #888;
+    }
+    .ai-history-signal {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 3px;
+        font-weight: 600;
+        font-size: 0.7rem;
+        color: #fff;
+    }
+    .ai-history-conclusion {
+        font-size: 0.8rem;
+        color: #555;
     }
 </style>
 {% endblock %}
 
 {% block content %}
+<!-- AI分析模态框 -->
+<div id="aiModal" class="ai-modal-overlay d-none">
+    <div class="ai-modal">
+        <div class="ai-modal-header">
+            <div>
+                <h5 class="ai-modal-title" id="aiModalTitle">--</h5>
+                <div class="ai-modal-subtitle" id="aiModalSubtitle">--</div>
+            </div>
+            <button class="ai-modal-close" onclick="BriefingPage.closeAIModal()">&times;</button>
+        </div>
+        <div class="ai-modal-body">
+            <button class="ai-modal-btn" id="aiAnalyzeBtn" onclick="BriefingPage.runAIAnalysis()">
+                <i class="bi bi-robot"></i> AI智能分析
+            </button>
+            <div id="aiResultPanel"></div>
+            <div class="ai-history-section">
+                <div class="ai-history-title"><i class="bi bi-clock-history"></i> 历史分析记录</div>
+                <div id="aiHistoryList"></div>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- 页面标题 -->
 <div class="page-header mb-4">
     <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
- 移除股票卡片中的内联AI按钮
- 股票卡片支持点击，点击后弹出AI分析模态框
- 模态框包含AI智能分析按钮和历史分析记录
- 新增AI分析历史API端点 /briefing/api/ai/history
- 历史记录显示最近30天的分析结果（最多10条）
- 可点击历史记录查看详细分析内容

https://claude.ai/code/session_01Vb6kDaKj5jsMC4nJku9Sun