### PR TITLE
fix: 修复启动窗口中文乱码问题

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,5 @@
 @echo off
+chcp 65001 >nul
 cd /d "%~dp0"
 echo 正在启动股票管理工具...
 echo.


### PR DESCRIPTION
添加 chcp 65001 设置控制台为 UTF-8 代码页，解决 Windows 命令行中文显示乱码问题。

Slack thread: https://gsstockco.slack.com/archives/C0ADZUWME49/p1771122601419029

https://claude.ai/code/session_01XBQVhXDpRVNAMfeDt47woE