### PR TITLE
fix: CockroachDB 序列化冲突改用 UPSERT 原子操作

### DIFF
--- a/app/models/unified_cache.py
+++ b/app/models/unified_cache.py
@@ -7,8 +7,10 @@ import json
 import logging
 from datetime import datetime, date
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.dialects.postgresql import insert
 from app import db
-from app.utils.db_retry import is_retryable_error, with_db_retry, MAX_RETRIES
+from app.utils.db_retry import is_retryable_error, with_db_retry, MAX_RETRIES, _get_retry_delay
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -102,33 +104,65 @@ class UnifiedStockCache(db.Model):
         return None
 
     @classmethod
-    @with_db_retry
     def set_cached_data(cls, stock_code: str, cache_type: str, data: dict | list,
                         cache_date: date = None, is_complete: bool = False,
                         data_end_date: date = None) -> 'UnifiedStockCache':
-        """设置缓存数据（带CockroachDB重试）"""
+        """设置缓存数据（使用UPSERT避免序列化冲突）"""
         if cache_date is None:
             cache_date = date.today()
 
-        cache = cls.query.filter_by(
-            stock_code=stock_code,
-            cache_type=cache_type,
-            cache_date=cache_date
-        ).first()
+        now = datetime.now()
+        data_json = json.dumps(data, ensure_ascii=False)
 
-        if cache:
-            cache.set_data(data, is_complete, data_end_date)
-        else:
-            cache = cls(
-                stock_code=stock_code,
-                cache_type=cache_type,
-                cache_date=cache_date,
-            )
-            cache.set_data(data, is_complete, data_end_date)
-            db.session.add(cache)
+        # 使用 INSERT ... ON CONFLICT DO UPDATE (UPSERT) 避免读-写竞态
+        values = {
+            'stock_code': stock_code,
+            'cache_type': cache_type,
+            'cache_date': cache_date,
+            'data_json': data_json,
+            'last_fetch_time': now,
+            'is_complete': is_complete,
+            'data_end_date': data_end_date,
+            'created_at': now,
+            'updated_at': now,
+        }
 
-        db.session.commit()
-        return cache
+        stmt = insert(cls.__table__).values(**values)
+
+        # 冲突时更新这些列
+        upsert_stmt = stmt.on_conflict_do_update(
+            index_elements=['stock_code', 'cache_type', 'cache_date'],
+            set_={
+                'data_json': stmt.excluded.data_json,
+                'last_fetch_time': stmt.excluded.last_fetch_time,
+                'is_complete': stmt.excluded.is_complete,
+                'data_end_date': stmt.excluded.data_end_date,
+                'updated_at': stmt.excluded.updated_at,
+            }
+        )
+
+        last_error = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                db.session.execute(upsert_stmt)
+                db.session.commit()
+                # 返回缓存对象以保持API兼容
+                return cls.query.filter_by(
+                    stock_code=stock_code,
+                    cache_type=cache_type,
+                    cache_date=cache_date
+                ).first()
+            except OperationalError as e:
+                last_error = e
+                if is_retryable_error(e) and attempt < MAX_RETRIES - 1:
+                    delay = _get_retry_delay(attempt)
+                    logger.warning(f"[DB重试] set_cached_data UPSERT 操作失败，重试 {attempt + 1}/{MAX_RETRIES}，延迟 {delay:.3f}s: {type(e).__name__}")
+                    db.session.rollback()
+                    time.sleep(delay)
+                    continue
+                raise
+        if last_error:
+            raise last_error
 
     @classmethod
     def get_batch_cached_data(cls, stock_codes: list, cache_type: str,
@@ -258,10 +292,11 @@ class UnifiedStockCache(db.Model):
         return result
 
     @classmethod
-    @with_db_retry
     def mark_complete(cls, stock_code: str, cache_type: str,
                       cache_date: date = None, data_end_date: date = None) -> bool:
         """标记缓存数据为完整
+
+        使用原子UPDATE避免序列化冲突。
 
         Args:
             stock_code: 股票代码
@@ -275,21 +310,37 @@ class UnifiedStockCache(db.Model):
         if cache_date is None:
             cache_date = date.today()
 
-        cache = cls.query.filter_by(
-            stock_code=stock_code,
-            cache_type=cache_type,
-            cache_date=cache_date
-        ).first()
+        now = datetime.now()
 
-        if not cache:
-            return False
-
-        cache.is_complete = True
+        # 使用原子UPDATE避免读-写竞态
+        update_values = {
+            'is_complete': True,
+            'updated_at': now,
+        }
         if data_end_date:
-            cache.data_end_date = data_end_date
-        cache.updated_at = datetime.now()
-        db.session.commit()
-        return True
+            update_values['data_end_date'] = data_end_date
+
+        last_error = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                result = cls.query.filter_by(
+                    stock_code=stock_code,
+                    cache_type=cache_type,
+                    cache_date=cache_date
+                ).update(update_values)
+                db.session.commit()
+                return result > 0
+            except OperationalError as e:
+                last_error = e
+                if is_retryable_error(e) and attempt < MAX_RETRIES - 1:
+                    delay = _get_retry_delay(attempt)
+                    logger.warning(f"[DB重试] mark_complete 操作失败，重试 {attempt + 1}/{MAX_RETRIES}，延迟 {delay:.3f}s: {type(e).__name__}")
+                    db.session.rollback()
+                    time.sleep(delay)
+                    continue
+                raise
+        if last_error:
+            raise last_error
 
     @classmethod
     def get_data_end_dates(cls, stock_codes: list, cache_type: str,

--- a/app/utils/db_retry.py
+++ b/app/utils/db_retry.py
@@ -4,16 +4,26 @@ CockroachDB 在并发事务冲突或连接断开时需要客户端自动重试�
 
 - 读操作：通过 setup_db_retry() patch Session.execute 自动重试
 - 写操作：使用 @with_db_retry 装饰器在业务层重试整个事务
+- UPSERT操作：使用 upsert_with_retry() 避免读-写竞态
 """
 import time
+import random
 import logging
 from functools import wraps
 from sqlalchemy.exc import OperationalError, DisconnectionError
 
 logger = logging.getLogger(__name__)
 
-MAX_RETRIES = 3
+MAX_RETRIES = 5  # 增加重试次数以应对高并发场景
 RETRY_DELAY = 0.1
+RETRY_JITTER = 0.05  # 随机抖动，减少重试碰撞
+
+
+def _get_retry_delay(attempt: int) -> float:
+    """计算带抖动的重试延迟"""
+    base_delay = RETRY_DELAY * (2 ** attempt)
+    jitter = random.uniform(-RETRY_JITTER, RETRY_JITTER) * base_delay
+    return base_delay + jitter
 
 
 def is_retryable_error(error):
@@ -40,16 +50,22 @@ def with_db_retry(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         from app import db
+        last_error = None
         for attempt in range(MAX_RETRIES):
             try:
                 return func(*args, **kwargs)
             except (OperationalError, DisconnectionError) as e:
+                last_error = e
                 if is_retryable_error(e) and attempt < MAX_RETRIES - 1:
-                    logger.warning(f"[DB重试] {func.__name__} 数据库错误，重试 {attempt + 1}/{MAX_RETRIES}: {e}")
+                    delay = _get_retry_delay(attempt)
+                    logger.warning(f"[DB重试] {func.__name__} 数据库错误，重试 {attempt + 1}/{MAX_RETRIES}，延迟 {delay:.3f}s: {type(e).__name__}")
                     db.session.rollback()
-                    time.sleep(RETRY_DELAY * (2 ** attempt))
+                    time.sleep(delay)
                     continue
                 raise
+        # 所有重试都失败
+        if last_error:
+            raise last_error
     return wrapper
 
 
@@ -78,8 +94,9 @@ def setup_db_retry(db, app):
                         self.rollback()
                         if has_pending:
                             raise
-                        logger.warning(f"[DB重试] 读查询连接错误，自动重试 {attempt + 1}/{MAX_RETRIES}: {e}")
-                        time.sleep(RETRY_DELAY * (2 ** attempt))
+                        delay = _get_retry_delay(attempt)
+                        logger.warning(f"[DB重试] 读查询连接错误，自动重试 {attempt + 1}/{MAX_RETRIES}，延迟 {delay:.3f}s: {type(e).__name__}")
+                        time.sleep(delay)
                         continue
                     raise
 
@@ -87,3 +104,48 @@ def setup_db_retry(db, app):
         logger.info("[DB重试] Session.execute 自动读重试已启用（含连接层错误）")
     except Exception as e:
         logger.warning(f"[DB重试] 无法启用Session级自动重试: {e}")
+
+
+def execute_upsert(db, table, values: dict, index_elements: list, update_columns: list):
+    """执行 UPSERT 操作，避免读-写竞态导致的序列化冲突
+
+    使用 INSERT ... ON CONFLICT DO UPDATE 语法，原子性地插入或更新记录。
+
+    Args:
+        db: Flask-SQLAlchemy db 实例
+        table: SQLAlchemy Table 对象（如 Model.__table__）
+        values: 要插入的值字典
+        index_elements: 唯一约束列名列表（用于冲突检测）
+        update_columns: 冲突时要更新的列名列表
+
+    Returns:
+        执行结果
+    """
+    from sqlalchemy.dialects.postgresql import insert
+
+    stmt = insert(table).values(**values)
+
+    update_dict = {col: stmt.excluded[col] for col in update_columns}
+
+    upsert_stmt = stmt.on_conflict_do_update(
+        index_elements=index_elements,
+        set_=update_dict
+    )
+
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            result = db.session.execute(upsert_stmt)
+            db.session.commit()
+            return result
+        except (OperationalError, DisconnectionError) as e:
+            last_error = e
+            if is_retryable_error(e) and attempt < MAX_RETRIES - 1:
+                delay = _get_retry_delay(attempt)
+                logger.warning(f"[DB重试] UPSERT 操作失败，重试 {attempt + 1}/{MAX_RETRIES}，延迟 {delay:.3f}s: {type(e).__name__}")
+                db.session.rollback()
+                time.sleep(delay)
+                continue
+            raise
+    if last_error:
+        raise last_error


### PR DESCRIPTION
- set_cached_data 从读-写模式改为 INSERT ... ON CONFLICT DO UPDATE
- mark_complete 改用原子 UPDATE 避免竞态
- 增加重试次数 3→5，添加随机抖动减少碰撞
- 新增 execute_upsert 通用帮助函数

修复 WriteTooOldError 导致的频繁重试问题。

https://claude.ai/code/session_01EeWMpT2fLb1KYNVZ1ZcGJL