### PR TITLE
fix: LLM请求超时默认值改为300秒

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,8 +45,8 @@ SECRET_KEY=
 # LLM 日预算上限（美元），默认 5.0
 # LLM_DAILY_BUDGET=5.0
 
-# LLM API 请求超时（秒），默认 60
-# LLM_REQUEST_TIMEOUT=60
+# LLM API 请求超时（秒），默认 300
+# LLM_REQUEST_TIMEOUT=300
 
 # ============ 通知配置（可选） ============
 # 策略引擎检测到信号后推送通知，配置对应变量后自动启用

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ PreloadService.get_indices_data()
 |---------|------|-------|
 | `ZHIPU_API_KEY` | 智谱 GLM API 密钥 | 空 |
 | `LLM_DAILY_BUDGET` | 日预算上限（美元） | `5.0` |
-| `LLM_REQUEST_TIMEOUT` | API 请求超时（秒） | `60` |
+| `LLM_REQUEST_TIMEOUT` | API 请求超时（秒） | `300` |
 
 ## 技术栈
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cp .env.sample .env
 | `POLYGON_API_KEY` | Polygon.io 密钥（可选，仅美股） | 空 |
 | `ZHIPU_API_KEY` | 智谱 GLM 密钥（可选，AI 分析） | 空 |
 | `LLM_DAILY_BUDGET` | LLM 日预算上限（美元） | `5.0` |
-| `LLM_REQUEST_TIMEOUT` | LLM API 请求超时（秒） | `60` |
+| `LLM_REQUEST_TIMEOUT` | LLM API 请求超时（秒） | `300` |
 | `SLACK_WEBHOOK_URL` | Slack 推送（可选） | 空 |
 | `WATCH_INTERVAL_MINUTES` | 盯盘刷新间隔（分钟） | `1` |
 
@@ -147,7 +147,7 @@ Windows 用户可双击 `start.bat` 一键启动并打开浏览器。
 ```env
 ZHIPU_API_KEY=your_key_here
 LLM_DAILY_BUDGET=5.0      # 日预算上限（美元），默认 5.0
-LLM_REQUEST_TIMEOUT=60    # API 请求超时（秒），默认 60
+LLM_REQUEST_TIMEOUT=300    # API 请求超时（秒），默认 300
 ```
 
 配置 `ZHIPU_API_KEY` 后自动启用 AI 分析功能。预算用尽时自动降级到 Flash 层。

--- a/app/llm/providers/zhipu.py
+++ b/app/llm/providers/zhipu.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 ZHIPU_API_KEY = os.environ.get('ZHIPU_API_KEY', '')
 ZHIPU_BASE_URL = 'https://open.bigmodel.cn/api/paas/v4'
-LLM_REQUEST_TIMEOUT = int(os.environ.get('LLM_REQUEST_TIMEOUT', '60'))
+LLM_REQUEST_TIMEOUT = int(os.environ.get('LLM_REQUEST_TIMEOUT', '300'))
 
 
 class ZhipuFlashProvider(LLMProvider):


### PR DESCRIPTION
修复新闻监控AI简报超时问题，将 LLM_REQUEST_TIMEOUT 默认值从60秒
增加到300秒，给智谱GLM更充足的响应时间。

Slack thread: https://gsstockco.slack.com/archives/C0ADZUWME49/p1772107502412229

https://claude.ai/code/session_01Dzc3qefAEPrpMkfxokD1Xx