### PR TITLE
fix: 修复新闻看板一直显示加载中的问题

### DIFF
--- a/app/static/js/news.js
+++ b/app/static/js/news.js
@@ -43,6 +43,8 @@ const News = {
             this.showContent();
         } catch (e) {
             console.error('加载失败:', e);
+            this.items = [];
+            this.showContent();
         }
     },
 
@@ -52,11 +54,13 @@ const News = {
             const data = await resp.json();
             if (data.success) {
                 this.items = data.items;
-                this.renderItems();
-                this.showContent();
             }
+            this.renderItems();
+            this.showContent();
         } catch (e) {
             console.error('加载快讯失败:', e);
+            this.items = [];
+            this.showContent();
         }
     },
 


### PR DESCRIPTION
当 API 请求失败时，loadData() 和 loadItems() 的 catch 块没有调用 showContent()，导致页面一直停留在"加载中..."状态。

修复方案：在 catch 块中清空 items 并调用 showContent()，确保即使
请求失败也能正确显示空状态界面。

Slack: https://gsstockco.slack.com/archives/C0ADZUWME49/p1772108530995589

https://claude.ai/code/session_01E8SUjhxtDPXbd1kQktLXdr