### PR TITLE
feat(策略): 添加独立 GitHub Release 监控策略

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -99,6 +99,10 @@ NEWS_DERIVATION_ENABLED=false
 # 取前 N 个项目（默认 10）
 # GITHUB_TRENDING_TOP_N=10
 
+# ============ GitHub Release 监控 ============
+# 监控关注仓库的新版本发布，每 6 小时检查一次，推送到 news_ai_tool
+# GITHUB_RELEASE_ENABLED=true
+
 # ============ 赛事推送 ============
 # 每日推送中展示 NBA / LoL 赛程和结果
 # ESPORTS_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,7 +316,10 @@ TDSequentialService.calculate()
 
 | 环境变量 | 说明 | 默认值 |
 |---------|------|-------|
+| `GITHUB_RELEASE_ENABLED` | 是否启用 GitHub Release 监控 | `true` |
 | `CLAUDE_PLUGINS_DIR` | Claude Code 插件目录（动态发现本地已装插件所属仓库） | `~/.claude/plugins` |
+
+独立调度策略 `github_release`：每 6 小时检查一次新版本（`0 */6 * * *`），发现新 Release 立即推送到 `news_ai_tool` 频道。
 
 监控仓库列表 = 静态配置（`app/config/github_releases.py` 的 `GITHUB_RELEASE_REPOS`） ∪ 本地已装 Claude Code 插件对应 marketplace 仓库，按 `repo` 去重（静态优先保留自定义 `name`/`emoji`/`key`）。
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cp .env.sample .env
 | `BLOG_MONITOR_ENABLED` | 是否启用博客监控 | `true` |
 | `GITHUB_TRENDING_ENABLED` | 是否启用 GitHub Trending 监控 | `true` |
 | `GITHUB_TRENDING_TOP_N` | 取前 N 个项目 | `10` |
+| `GITHUB_RELEASE_ENABLED` | 是否启用 GitHub Release 监控（每6小时检查） | `true` |
 | `ESPORTS_ENABLED` | 是否启用赛事推送（NBA/LoL） | `true` |
 | `ESPORTS_FETCH_TIMEOUT` | 赛事API请求超时（秒） | `15` |
 | `ESPORTS_NBA_MONITOR_INTERVAL` | NBA 比分轮询间隔（分钟） | `15` |

--- a/app/strategies/github_release/__init__.py
+++ b/app/strategies/github_release/__init__.py
@@ -1,0 +1,35 @@
+"""GitHub Release 独立监控策略 - 每 6 小时检查一次新版本"""
+import logging
+import os
+from app.strategies.base import Strategy, Signal
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubReleaseStrategy(Strategy):
+    name = "github_release"
+    description = "GitHub Release 版本监控"
+    schedule = "0 */6 * * *"
+    needs_llm = True
+    enabled = os.environ.get('GITHUB_RELEASE_ENABLED', 'true').lower() == 'true'
+
+    def scan(self) -> list[Signal]:
+        from app.services.notification import NotificationService
+        from app.services.github_release import GitHubReleaseService
+        from app.config.notification_config import CHANNEL_AI_TOOL
+
+        release_texts, release_pushed_versions = NotificationService.format_github_release_updates()
+
+        if not release_texts:
+            logger.info('[GitHub Release] 无新版本')
+            return []
+
+        msg = '\n\n'.join(release_texts)
+        if NotificationService.send_slack(msg, CHANNEL_AI_TOOL):
+            logger.info(f'[GitHub Release] 推送成功: {len(release_texts)} 个仓库')
+            for key, version in release_pushed_versions:
+                GitHubReleaseService.mark_pushed_version(key, version)
+        else:
+            logger.warning('[GitHub Release] 推送失败')
+
+        return []


### PR DESCRIPTION
之前 GitHub Release 检查仅在每日简报中执行（早上 8 点），导致当天新发布的版本要等到次日才会推送。

新增 `github_release` 策略，每 6 小时独立调度检查新版本，发现更新立即推送到 `news_ai_tool` 频道。

- 新增 `GITHUB_RELEASE_ENABLED` 环境变量控制开关
- 同步更新 CLAUDE.md、README.md、.env.sample 配置文档

https://claude.ai/code/session_015yFLCVSrq7VAhfhnSWcrD5